### PR TITLE
Adding PowerLink link function in GLM

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -85,6 +85,7 @@ LogLink
 NegativeBinomialLink
 ProbitLink
 SqrtLink
+PowerLink
 GLM.linkfun
 GLM.linkinv
 GLM.mueta

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -340,7 +340,7 @@ julia> round(deviance(gm1), digits=5)
 5.11746
 ```
 ## Linear regression with PowerLink.
-## Choose the best model from a set of λs, based on minimum BIC
+### Choose the best model from a set of λs, based on minimum BIC
 
 ```jldoctest
 julia> using GLM, RDatasets, StatsBase, DataFrames, Optim;

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -339,3 +339,84 @@ Treatment: 3   0.0198026    0.199017   0.10    0.9207  -0.370264   0.409869
 julia> round(deviance(gm1), digits=5)
 5.11746
 ```
+## Linear regression with PowerLink.
+## Choose the best model from a set of λs, based on minimum BIC
+
+```jldoctest
+julia> using GLM, RDatasets, StatsBase, DataFrames
+
+julia> trees = DataFrame(dataset("datasets", "trees"))
+31×3 typename(DataFrame)
+│ Row │ Girth   │ Height │ Volume  │
+│     │ Float64 │ Int64  │ Float64 │
+├─────┼─────────┼────────┼─────────┤
+│ 1   │ 8.3     │ 70     │ 10.3    │
+│ 2   │ 8.6     │ 65     │ 10.3    │
+│ 3   │ 8.8     │ 63     │ 10.2    │
+│ 4   │ 10.5    │ 72     │ 16.4    │
+│ 5   │ 10.7    │ 81     │ 18.8    │
+│ 6   │ 10.8    │ 83     │ 19.7    │
+│ 7   │ 11.0    │ 66     │ 15.6    │
+│ 8   │ 11.0    │ 75     │ 18.2    │
+│ 9   │ 11.1    │ 80     │ 22.6    │
+│ 10  │ 11.2    │ 75     │ 19.9    │
+│ 11  │ 11.3    │ 79     │ 24.2    │
+│ 12  │ 11.4    │ 76     │ 21.0    │
+│ 13  │ 11.4    │ 76     │ 21.4    │
+│ 14  │ 11.7    │ 69     │ 21.3    │
+│ 15  │ 12.0    │ 75     │ 19.1    │
+│ 16  │ 12.9    │ 74     │ 22.2    │
+│ 17  │ 12.9    │ 85     │ 33.8    │
+│ 18  │ 13.3    │ 86     │ 27.4    │
+│ 19  │ 13.7    │ 71     │ 25.7    │
+│ 20  │ 13.8    │ 64     │ 24.9    │
+│ 21  │ 14.0    │ 78     │ 34.5    │
+│ 22  │ 14.2    │ 80     │ 31.7    │
+│ 23  │ 14.5    │ 74     │ 36.3    │
+│ 24  │ 16.0    │ 72     │ 38.3    │
+│ 25  │ 16.3    │ 77     │ 42.6    │
+│ 26  │ 17.3    │ 81     │ 55.4    │
+│ 27  │ 17.5    │ 82     │ 55.7    │
+│ 28  │ 17.9    │ 80     │ 58.3    │
+│ 29  │ 18.0    │ 80     │ 51.5    │
+│ 30  │ 18.0    │ 80     │ 51.0    │
+│ 31  │ 20.6    │ 87     │ 77.0    │
+
+julia> min_bic = Inf
+Inf
+
+julia> min_λ = -1
+-1
+
+julia> best_glm = Nothing
+Nothing
+
+julia> for λ = -1:0.05:1
+           mdl = glm(@formula(Volume ~ Height + Girth), trees, Normal(), PowerLink(λ))
+           current_bic = bic(mdl)
+           if current_bic < min_bic
+                   min_bic = current_bic
+               min_λ = λ
+               best_glm = mdl
+           end
+       end
+julia> println("Best λ = ", min_λ)
+Best λ = 0.4
+
+julia> println(best_glm)
+StatsModels.TableRegressionModel{GeneralizedLinearModel{GLM.GlmResp{Vector{Float64}, Normal{Float64}, PowerLink}, GLM.DensePredChol{Float64, LinearAlgebra.Cholesky{Float64, Matrix{Float64}}}}, Matrix{Float64}}
+
+Volume ~ 1 + Height + Girth
+
+Coefficients:
+────────────────────────────────────────────────────────────────────────────
+                  Coef.  Std. Error      z  Pr(>|z|)   Lower 95%   Upper 95%
+────────────────────────────────────────────────────────────────────────────
+(Intercept)  -0.921422   0.333867    -2.76    0.0058  -1.57579    -0.267055
+Height        0.0219293  0.00495871   4.42    <1e-05   0.0122104   0.0316482
+Girth         0.229436   0.00873054  26.28    <1e-99   0.212325    0.246548
+────────────────────────────────────────────────────────────────────────────
+
+julia> println("BIC = ", min_bic)
+BIC = 156.3851822437326
+```

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -343,65 +343,57 @@ julia> round(deviance(gm1), digits=5)
 ## Choose the best model from a set of λs, based on minimum BIC
 
 ```jldoctest
-julia> using GLM, RDatasets, StatsBase, DataFrames
+julia> using GLM, RDatasets, StatsBase, DataFrames, Optim;
 
-julia> trees = DataFrame(dataset("datasets", "trees"))
-31×3 typename(DataFrame)
-│ Row │ Girth   │ Height │ Volume  │
-│     │ Float64 │ Int64  │ Float64 │
-├─────┼─────────┼────────┼─────────┤
-│ 1   │ 8.3     │ 70     │ 10.3    │
-│ 2   │ 8.6     │ 65     │ 10.3    │
-│ 3   │ 8.8     │ 63     │ 10.2    │
-│ 4   │ 10.5    │ 72     │ 16.4    │
-│ 5   │ 10.7    │ 81     │ 18.8    │
-│ 6   │ 10.8    │ 83     │ 19.7    │
-│ 7   │ 11.0    │ 66     │ 15.6    │
-│ 8   │ 11.0    │ 75     │ 18.2    │
-│ 9   │ 11.1    │ 80     │ 22.6    │
-│ 10  │ 11.2    │ 75     │ 19.9    │
-│ 11  │ 11.3    │ 79     │ 24.2    │
-│ 12  │ 11.4    │ 76     │ 21.0    │
-│ 13  │ 11.4    │ 76     │ 21.4    │
-│ 14  │ 11.7    │ 69     │ 21.3    │
-│ 15  │ 12.0    │ 75     │ 19.1    │
-│ 16  │ 12.9    │ 74     │ 22.2    │
-│ 17  │ 12.9    │ 85     │ 33.8    │
-│ 18  │ 13.3    │ 86     │ 27.4    │
-│ 19  │ 13.7    │ 71     │ 25.7    │
-│ 20  │ 13.8    │ 64     │ 24.9    │
-│ 21  │ 14.0    │ 78     │ 34.5    │
-│ 22  │ 14.2    │ 80     │ 31.7    │
-│ 23  │ 14.5    │ 74     │ 36.3    │
-│ 24  │ 16.0    │ 72     │ 38.3    │
-│ 25  │ 16.3    │ 77     │ 42.6    │
-│ 26  │ 17.3    │ 81     │ 55.4    │
-│ 27  │ 17.5    │ 82     │ 55.7    │
-│ 28  │ 17.9    │ 80     │ 58.3    │
-│ 29  │ 18.0    │ 80     │ 51.5    │
-│ 30  │ 18.0    │ 80     │ 51.0    │
-│ 31  │ 20.6    │ 87     │ 77.0    │
+julia> trees = DataFrame(dataset("datasets", "trees"));
 
-julia> min_bic = Inf
-Inf
+julia> print(trees)
+31×3 DataFrame
+ Row │ Girth    Height  Volume  
+     │ Float64  Int64   Float64 
+─────┼──────────────────────────
+   1 │     8.3      70     10.3
+   2 │     8.6      65     10.3
+   3 │     8.8      63     10.2
+   4 │    10.5      72     16.4
+   5 │    10.7      81     18.8
+   6 │    10.8      83     19.7
+   7 │    11.0      66     15.6
+   8 │    11.0      75     18.2
+   9 │    11.1      80     22.6
+  10 │    11.2      75     19.9
+  11 │    11.3      79     24.2
+  12 │    11.4      76     21.0
+  13 │    11.4      76     21.4
+  14 │    11.7      69     21.3
+  15 │    12.0      75     19.1
+  16 │    12.9      74     22.2
+  17 │    12.9      85     33.8
+  18 │    13.3      86     27.4
+  19 │    13.7      71     25.7
+  20 │    13.8      64     24.9
+  21 │    14.0      78     34.5
+  22 │    14.2      80     31.7
+  23 │    14.5      74     36.3
+  24 │    16.0      72     38.3
+  25 │    16.3      77     42.6
+  26 │    17.3      81     55.4
+  27 │    17.5      82     55.7
+  28 │    17.9      80     58.3
+  29 │    18.0      80     51.5
+  30 │    18.0      80     51.0
+  31 │    20.6      87     77.0
 
-julia> min_λ = -1
--1
+julia> bic_glm(λ)  = bic(glm(@formula(Volume ~ Height + Girth), trees, Normal(), PowerLink(λ)));
 
-julia> best_glm = Nothing
-Nothing
+julia> optimal_bic = optimize(bic_glm, -1.0, 1.0);
 
-julia> for λ = -1:0.05:1
-           mdl = glm(@formula(Volume ~ Height + Girth), trees, Normal(), PowerLink(λ))
-           current_bic = bic(mdl)
-           if current_bic < min_bic
-                   min_bic = current_bic
-               min_λ = λ
-               best_glm = mdl
-           end
-       end
-julia> println("Best λ = ", min_λ)
-Best λ = 0.4
+julia> min_λ = optimal_bic.minimizer;
+
+julia> best_glm = glm(@formula(Volume ~ Height + Girth), trees, Normal(), PowerLink(min_λ));
+
+julia> println("Best λ = ", round(min_λ, digits = 5))
+Best λ = 0.40935
 
 julia> println(best_glm)
 StatsModels.TableRegressionModel{GeneralizedLinearModel{GLM.GlmResp{Vector{Float64}, Normal{Float64}, PowerLink}, GLM.DensePredChol{Float64, LinearAlgebra.Cholesky{Float64, Matrix{Float64}}}}, Matrix{Float64}}
@@ -412,11 +404,11 @@ Coefficients:
 ────────────────────────────────────────────────────────────────────────────
                   Coef.  Std. Error      z  Pr(>|z|)   Lower 95%   Upper 95%
 ────────────────────────────────────────────────────────────────────────────
-(Intercept)  -0.921422   0.333867    -2.76    0.0058  -1.57579    -0.267055
-Height        0.0219293  0.00495871   4.42    <1e-05   0.0122104   0.0316482
-Girth         0.229436   0.00873054  26.28    <1e-99   0.212325    0.246548
+(Intercept)  -1.07586    0.352543    -3.05    0.0023  -1.76684    -0.384892
+Height        0.0232172  0.00523331   4.44    <1e-05   0.0129601   0.0334743
+Girth         0.242837   0.00922555  26.32    <1e-99   0.224756    0.260919
 ────────────────────────────────────────────────────────────────────────────
 
-julia> println("BIC = ", min_bic)
-BIC = 156.3851822437326
+julia> println("BIC = ", round(optimal_bic.minimum, digits=5))
+BIC = 156.37638
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -51,6 +51,7 @@ Currently the available Link types are
     NegativeBinomialLink
     ProbitLink
     SqrtLink
+    PowerLink
 
 Note that the canonical link for negative binomial regression is `NegativeBinomialLink`, but
 in practice one typically uses `LogLink`.

--- a/src/GLM.jl
+++ b/src/GLM.jl
@@ -44,6 +44,8 @@ module GLM
         NegativeBinomialLink,
         ProbitLink,
         SqrtLink,
+        # The proposed new link function: PowerLink
+        PowerLink,
 
         # Model types
         GeneralizedLinearModel,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1180,9 +1180,30 @@ end
         # Residual deviance:  184.16  on 28  degrees of freedom
         # AIC: 151.21
         #
-        mdl = glm(@formula(Volume ~ Height + Girth), trees, Normal(), PowerLink(1 / 3))
-        @test isapprox(coef(mdl), [-0.05132238692134761, 0.01428684676273272, 0.15033126098228242], atol=1.0e-5)
-        @test isapprox(aic(mdl), 151.21015973975, atol=1.0e-5)
-        @test isapprox(predict(mdl)[1], 10.59735275421753, atol=1.0e-5)
+        mdl = glm(@formula(Volume ~ Height + Girth), trees, Normal(), PowerLink(1 / 3); atol=1.0e-12, rtol=1.0e-12)
+        @test isapprox(coef(mdl), [-0.05132238692134761, 0.01428684676273272, 0.15033126098228242])
+        @test isapprox(aic(mdl), 151.21015973975)
+        @test isapprox(predict(mdl)[1], 10.59735275421753)
+    end
+    @testset "Compare PowerLink(0) and LogLink" begin
+        mdl1 = glm(@formula(Volume ~ Height + Girth), trees, Normal(), PowerLink(0))
+        mdl2 = glm(@formula(Volume ~ Height + Girth), trees, Normal(), LogLink())
+        @test isapprox(coef(mdl1), coef(mdl2))
+        @test isapprox(aic(mdl1), aic(mdl2))
+        @test isapprox(predict(mdl1), predict(mdl2))
+    end
+    @testset "Compare PowerLink(0.5) and SqrtLink" begin
+        mdl1 = glm(@formula(Volume ~ Height + Girth), trees, Normal(), PowerLink(0.5))
+        mdl2 = glm(@formula(Volume ~ Height + Girth), trees, Normal(), SqrtLink())
+        @test isapprox(coef(mdl1), coef(mdl2))
+        @test isapprox(aic(mdl1), aic(mdl2))
+        @test isapprox(predict(mdl1), predict(mdl2))
+    end
+    @testset "Compare PowerLink(1) and IdentityLink" begin
+        mdl1 = glm(@formula(Volume ~ Height + Girth), trees, Normal(), PowerLink(1))
+        mdl2 = glm(@formula(Volume ~ Height + Girth), trees, Normal(), IdentityLink())
+        @test isapprox(coef(mdl1), coef(mdl2))
+        @test isapprox(aic(mdl1), aic(mdl2))
+        @test isapprox(predict(mdl1), predict(mdl2))
     end
 end


### PR DESCRIPTION
PowerLink refers to the class of transforms that use a power function (e.g. a logarithm or an exponent) to transform responses into a Gaussian or a Gaussian-like.

The summaries of the changes in the following source files are:

- In docs/src/api.md:
  - Added PowerLink under the “Links and methods applied to them” section
- In docs/src/examples.md
  - Added an example “Linear regression with PowerLink. Choose the best model from a set of λs, based on minimum BIC”
- In docs/src/index.md:
  - Added PowerLink under the “Currently the available Link types are” section
- In src/GLM.jl:
  - Exported PowerLink
- In src/glmfit.jl
  - Added a member variable `link` to GlmResp structure. This is for storing details of the link function with parameters (if any)
- In GlmResp constructor, added one more argument to pass the link
  - Added updateμ! function specifically for PowerLink. Inside the function, the `inverselink’ function is called with PowerLink with the parameter, as the link function.
  - Added GLM.Link function specifically for PowerLink
- In src/glmtools.jl:
  - Added PowerLink to the docstring under “GLM currently supports the following links:”
  - Defined the Powerlink structure, λ is the parameter for this link function. The user needs to specify the λ.
  - Defined `linkfun` function for PowerLink
  - Defined `linkinv function `for PowerLink
  - Defined `mueta` function for PowerLink
  - Defined `inverselink` function for PowerLink
- In test/runtests.jl:
  - Added a set of test cases, which consisted of individual tests of all new functions related to PowerLink
  - Added a test case to compare against the R `glm()`
  - Added 3 test cases to check PowerLink with some special cases of PowerLink like LogLink, SqrtLink and IdentityLink.